### PR TITLE
little fix a french translation contextual word

### DIFF
--- a/public/locales/fr/main.json
+++ b/public/locales/fr/main.json
@@ -1,6 +1,6 @@
 {
   "save": "Enregistrer",
-  "saveAndSubmit": "Enregistrer et Envoyer",
+  "saveAndSubmit": "Enregistrer et Soumettre",
   "cancel": "Annuler",
   "confirm": "Confirmer",
   "warning": "Attention",


### PR DESCRIPTION
Better use "Soumettre" instead of "Envoyer" to translate "Submit". "Envoyer" is more contextually translation for the word "Send"