### PR TITLE
refactor: onClick can use useCallback hook 

### DIFF
--- a/src/components/AboutMenu/AboutMenu.tsx
+++ b/src/components/AboutMenu/AboutMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import PopupModal from '@components/PopupModal';
 import AboutIcon from '@icon/AboutIcon';
@@ -7,13 +7,15 @@ const AboutMenu = () => {
   const { t } = useTranslation(['main', 'about']);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
+  const handleClick = useCallback(() => {
+    setIsModalOpen(true);
+  }, [setIsModalOpen]);
+
   return (
     <>
       <a
         className='flex py-3 px-3 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm'
-        onClick={() => {
-          setIsModalOpen(true);
-        }}
+        onClick={handleClick}
       >
         <div>
           <AboutIcon />

--- a/src/components/ApiMenu/ApiMenu.tsx
+++ b/src/components/ApiMenu/ApiMenu.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import useStore from '@store/store';
 
 import PopupModal from '@components/PopupModal';
 import { availableEndpoints, defaultAPIEndpoint } from '@constants/auth';
 import DownChevronArrow from '@icon/DownChevronArrow';
+import { endpoint } from '@api/customApi';
 
 const ApiMenu = ({
   setIsModalOpen,
@@ -123,12 +124,21 @@ const ApiEndpointSelector = ({
 }) => {
   const [dropDown, setDropDown] = useState<boolean>(false);
 
+  const handleClick = useCallback(() => {
+    setDropDown((prev) => !prev);
+  }, []);
+
+  const handleApiEndpointChange = useCallback((endpoint: any) => {
+    _setApiEndpoint(endpoint);
+    setDropDown(false);
+  }, []);
+
   return (
     <div className='w-full relative'>
       <button
         className='btn btn-neutral btn-small flex w-32 flex justify-between w-full'
         type='button'
-        onClick={() => setDropDown((prev) => !prev)}
+        onClick={handleClick}
       >
         {_apiEndpoint}
         <DownChevronArrow />
@@ -146,10 +156,7 @@ const ApiEndpointSelector = ({
           {availableEndpoints.map((endpoint) => (
             <li
               className='px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer'
-              onClick={() => {
-                _setApiEndpoint(endpoint);
-                setDropDown(false);
-              }}
+              onClick={() => handleApiEndpointChange(endpoint)}
               key={endpoint}
             >
               {endpoint}


### PR DESCRIPTION
The onClick event handler creates a new function on every render, which may negatively affect performance. To avoid this, you can use the useCallback hook.

onClick can now use useCallback hook to trigger changes only when there's change wrt to its concerned state (if there's no change in the state then useCallback hook in react returns the same memoized version of function from previous render)