### PR TITLE
Fixed icons for mac version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       "title": "${productName} ${version}",
       "icon": "dist/icon-rounded.png"
     },
+    "mac": {
+      "icon": "dist/icon-rounded.png"
+    },
     "linux": {
       "target": [
         "tar.gz",


### PR DESCRIPTION
The mac version's icon was left as Electron's initial icon, so I fixed it so that it shows the same icon as the other versions.

- befor
![screenshot 2023-05-02 9 27 30](https://user-images.githubusercontent.com/44772513/235554647-8db9d94c-9993-4d94-a461-df9138b3652c.png)

- after
![screenshot 2023-05-02 9 28 58](https://user-images.githubusercontent.com/44772513/235554677-52a2f052-0f5b-4292-a952-f1e340b744d5.png)
