### PR TITLE
Refactor getToday function for improved readability and efficiency

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,10 +1,8 @@
 export const getToday = () => {
   const date = new Date();
-  const dateString =
-    date.getFullYear() +
-    '-' +
-    ('0' + (date.getMonth() + 1)).slice(-2) +
-    '-' +
-    ('0' + date.getDate()).slice(-2);
-  return dateString;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 };


### PR DESCRIPTION
Improves the readability and efficiency of the getToday function by using template literals and the padStart method. By using template literals, the code is more concise and easier to read. The padStart method ensures that both the month and day have two digits, which simplifies the string construction process. This change maintains the functionality of the original code while improving the overall quality and maintainability of the function.