### PR TITLE
Fixed 2 Electron Crashes

### DIFF
--- a/electron/index.cjs
+++ b/electron/index.cjs
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const { app, BrowserWindow, Tray, Menu } = require('electron');
+const {dialog,  app, BrowserWindow, Tray, Menu } = require('electron');
 const isDev = require('electron-is-dev');
 const { autoUpdater } = require('electron-updater');
 let win = null;
@@ -79,6 +79,14 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+process.on('uncaughtException', (error) => {
+  // Perform any necessary cleanup tasks here
+  dialog.showErrorBox('An error occurred', error.stack);
+
+  // Exit the app
+  process.exit(1);
 });
 
 if (!instanceLock) {

--- a/electron/index.cjs
+++ b/electron/index.cjs
@@ -3,6 +3,8 @@ const path = require('path');
 const { app, BrowserWindow, Tray, Menu } = require('electron');
 const isDev = require('electron-is-dev');
 const { autoUpdater } = require('electron-updater');
+let win = null;
+const instanceLock = app.requestSingleInstanceLock();
 
 if (require('electron-squirrel-startup')) app.quit();
 
@@ -17,7 +19,7 @@ function createWindow() {
   }
   autoUpdater.checkForUpdatesAndNotify();
 
-  const win = new BrowserWindow({
+  win = new BrowserWindow({
 	autoHideMenuBar: true,
     show: false,
     icon: iconPath,
@@ -73,19 +75,26 @@ const createTray = (window) => {
   return tray;
 };
 
-app.whenReady().then(createWindow);
-
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
 });
 
-app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
-  }
-});
+if (!instanceLock) {
+  app.quit()
+} else {
+  app.on('second-instance', (event, commandLine, workingDirectory) => {
+    if (win) {
+      if (win.isMinimized()) win.restore()
+      win.focus()
+    }
+  })
+
+  app.whenReady().then(() => {
+    win = createWindow()
+  })
+}
 
 const createServer = () => {
   // Dependencies


### PR DESCRIPTION
fixed crash on attempting to open new instance, required refactoring BrowserWindow to global:
`Uncaught Exception:
ReferenceError: win is not defined
at click (C:\Users\jacks\AppData\Local\Programs\better-chatgpt\resources\app.asar\electron\index.cjs:53:9)
at MenuItem.click (node:electron/js2c/browser_init:2:30166)
at a._executeCommand (node:electron/js2c/browser_init:2:35562)
`

fixed crash on attempting to open new instance, required refactoring BrowserWindow:
`Uncaught Exception:
ReferenceError: win is not defined
at click (C:\Users\jacks\AppData\Local\Programs\better-chatgpt\resources\app.asar\electron\index.cjs:53:9)
at MenuItem.click (node:electron/js2c/browser_init:2:30166)
at a._executeCommand (node:electron/js2c/browser_init:2:35562)`