### PR TITLE
ShareGPT feature can be toggled on and off in the menu

### DIFF
--- a/src/components/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/SettingsMenu/SettingsMenu.tsx
@@ -16,6 +16,7 @@ import ChatConfigMenu from '@components/ChatConfigMenu';
 import EnterToSubmitToggle from './EnterToSubmitToggle';
 import TotalTokenCost, { TotalTokenCostToggle } from './TotalTokenCost';
 import ClearConversation from '@components/Menu/MenuOptions/ClearConversation';
+import ShareGPTToggle from './ShareGPTToggle';
 
 const SettingsMenu = () => {
   const { t } = useTranslation();
@@ -51,6 +52,7 @@ const SettingsMenu = () => {
               <InlineLatexToggle />
               <AdvancedModeToggle />
               <TotalTokenCostToggle />
+              <ShareGPTToggle />
             </div>
             <ClearConversation />
             <PromptLibraryMenu />

--- a/src/components/SettingsMenu/ShareGPTToggle.tsx
+++ b/src/components/SettingsMenu/ShareGPTToggle.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import useStore from '@store/store';
+import Toggle from '@components/Toggle';
+
+const ShareGPTToggle = () => {
+  const { t } = useTranslation();
+
+  const setShareGPT = useStore((state) => state.setShareGPT);
+
+  const [isChecked, setIsChecked] = useState<boolean>(
+    useStore.getState().shareGPT
+  );
+
+  useEffect(() => {
+    setShareGPT(isChecked);
+  }, [isChecked]);
+
+  return (
+    <Toggle
+      label={t('postOnShareGPT.title') as string}
+      isChecked={isChecked}
+      setIsChecked={setIsChecked}
+    />
+  );
+};
+
+export default ShareGPTToggle;

--- a/src/components/ShareGPT/ShareGPT.tsx
+++ b/src/components/ShareGPT/ShareGPT.tsx
@@ -9,6 +9,7 @@ import { ShareGPTSubmitBodyInterface } from '@type/api';
 const ShareGPT = React.memo(() => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const isAvailable = useStore((state) => state.shareGPT);
 
   const handleConfirm = async () => {
     const chats = useStore.getState().chats;
@@ -40,14 +41,14 @@ const ShareGPT = React.memo(() => {
 
   return (
     <>
-      <button
+      { isAvailable && (<button
         className='btn btn-neutral'
         onClick={() => {
           setIsModalOpen(true);
         }}
       >
         {t('postOnShareGPT.title')}
-      </button>
+      </button>) }
       {isModalOpen && (
         <PopupModal
           setIsModalOpen={setIsModalOpen}

--- a/src/store/config-slice.ts
+++ b/src/store/config-slice.ts
@@ -7,6 +7,7 @@ export interface ConfigSlice {
   openConfig: boolean;
   theme: Theme;
   autoTitle: boolean;
+  shareGPT: boolean;
   hideMenuOptions: boolean;
   advancedMode: boolean;
   defaultChatConfig: ConfigInterface;
@@ -20,6 +21,7 @@ export interface ConfigSlice {
   setOpenConfig: (openConfig: boolean) => void;
   setTheme: (theme: Theme) => void;
   setAutoTitle: (autoTitle: boolean) => void;
+  setShareGPT: (autoTitle: boolean) => void;
   setAdvancedMode: (advancedMode: boolean) => void;
   setDefaultChatConfig: (defaultChatConfig: ConfigInterface) => void;
   setDefaultSystemMessage: (defaultSystemMessage: string) => void;
@@ -38,6 +40,7 @@ export const createConfigSlice: StoreSlice<ConfigSlice> = (set, get) => ({
   hideMenuOptions: false,
   hideSideMenu: false,
   autoTitle: false,
+  shareGPT: false,
   enterToSubmit: true,
   advancedMode: true,
   defaultChatConfig: _defaultChatConfig,
@@ -62,6 +65,12 @@ export const createConfigSlice: StoreSlice<ConfigSlice> = (set, get) => ({
     set((prev: ConfigSlice) => ({
       ...prev,
       autoTitle: autoTitle,
+    }));
+  },
+  setShareGPT: (shareGPT: boolean) => {
+    set((prev: ConfigSlice) => ({
+      ...prev,
+      shareGPT: shareGPT,
     }));
   },
   setAdvancedMode: (advancedMode: boolean) => {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -46,6 +46,7 @@ export const createPartializedState = (state: StoreState) => ({
   apiEndpoint: state.apiEndpoint,
   theme: state.theme,
   autoTitle: state.autoTitle,
+  shareGPT: state.shareGPT,
   advancedMode: state.advancedMode,
   prompts: state.prompts,
   defaultChatConfig: state.defaultChatConfig,


### PR DESCRIPTION
The goal is to prevent employees from accidentally posting content to ShareGPT while using BetterChatGPT for work. To achieve this, a warning dialog will appear when the ShareGPT button is pressed. Additionally, a toggle will be added to the menu function to allow for safer and more controlled use of ShareGPT.

I started a topic in the discussion but no one seemed to see it, so I created a PR.
https://github.com/ztjhz/BetterChatGPT/discussions/312

Below is a demo I tried to implement
https://user-images.githubusercontent.com/1217706/241082889-df31c7c2-72cf-4423-b6a9-d167379afe02.gif
