### PR TITLE
Adding prompt token count

### DIFF
--- a/src/components/Chat/ChatContent/Message/View/EditView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/EditView.tsx
@@ -9,7 +9,7 @@ import { ChatInterface } from '@type/chat';
 import PopupModal from '@components/PopupModal';
 import TokenCount from '@components/TokenCount';
 import CommandPrompt from '../CommandPrompt';
-
+import PromptInputTokenCount from '@components/PromptInputTokenCount';
 const EditView = ({
   content,
   setIsEdit,
@@ -121,6 +121,7 @@ const EditView = ({
 
   return (
     <>
+      <PromptInputTokenCount content={_content} role={inputRole} />
       <div
         className={`w-full ${
           sticky

--- a/src/components/PromptInputTokenCount/PromptInputTokenCount.tsx
+++ b/src/components/PromptInputTokenCount/PromptInputTokenCount.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import useStore from '@store/store';
+import countTokens from '@utils/messageUtils';
+import { defaultModel, modelCost } from '@constants/chat';
+
+interface TokenCountProps {
+  content: string;
+  role: 'user' | 'assistant' | 'system';
+}
+const TokenCount = React.memo<TokenCountProps>(({ content, role }) => {
+  const [tokenCount, setTokenCount] = useState<number>(0);
+  const generating = useStore((state) => state.generating);
+  const model = useStore((state) =>
+    state.chats
+      ? state.chats[state.currentChatIndex].config.model
+      : defaultModel
+  );
+
+  const cost = useMemo(() => {
+    const price =
+      modelCost[model].prompt.price *
+      (tokenCount / modelCost[model].prompt.unit);
+    return price.toPrecision(3);
+  }, [model, tokenCount]);
+
+  useEffect(() => {
+    if (!generating && content && content.length > 0) {
+      setTokenCount(
+        countTokens(
+          [
+            {
+              content,
+              role: role,
+            },
+          ],
+          model
+        )
+      );
+    } else {
+      setTokenCount(0);
+    }
+  }, [content, generating]);
+
+  return (
+    <div className='top-[-16px] left-0'>
+      <div className='text-xs italic text-gray-900 dark:text-gray-300'>
+        Prompt tokens count: {tokenCount} (${cost})
+      </div>
+    </div>
+  );
+});
+
+export default TokenCount;

--- a/src/components/PromptInputTokenCount/index.ts
+++ b/src/components/PromptInputTokenCount/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PromptInputTokenCount';


### PR DESCRIPTION
First off, thank you for all the efforts getting such nice and feature rich app!
Second, I have been using this project for a while and added couple of small features to it.
One of them is that I found handy when dealing with lengthy prompts is some token counting and cost calculation.
Which is exactly what I added in this PR (you can see on the top left corner above the prompt text area)
<img width="2672" alt="Screenshot 2023-07-01 at 22 44 59" src="https://github.com/ztjhz/BetterChatGPT/assets/5157350/79569214-b6d9-4979-84f9-2edcf3b5151b">

