### PR TITLE
Show title for when the title is too long

### DIFF
--- a/src/components/Menu/ChatHistory.tsx
+++ b/src/components/Menu/ChatHistory.tsx
@@ -101,7 +101,7 @@ const ChatHistory = React.memo(
         onDragStart={handleDragStart}
       >
         <ChatIcon />
-        <div className='flex-1 text-ellipsis max-h-5 overflow-hidden break-all relative'>
+        <div className='flex-1 text-ellipsis max-h-5 overflow-hidden break-all relative' title={title}>
           {isEdit ? (
             <input
               type='text'


### PR DESCRIPTION
Add a title attribue to the div showing the chat title.

This helps to quickly see the full title on hover

<img width="460" alt="Screenshot 2023-07-10 at 9 12 38 pm" src="https://github.com/ztjhz/BetterChatGPT/assets/2367456/43404543-e348-4d50-a59c-88098df5abf3">
