### PR TITLE
Add "advanced models" ModelSelector expansion

### DIFF
--- a/src/components/ConfigMenu/ConfigMenu.tsx
+++ b/src/components/ConfigMenu/ConfigMenu.tsx
@@ -113,7 +113,7 @@ export const ModelSelector = ({
         >
           {filteredModelOptions.map((m,i) => (
             <li
-              className='px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer'
+            className={`px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer${i === 0 ? " rounded-t-lg" : ""}${i > modelOptions.indexOf('gpt-4-32k') ? "text-gray-600 dark:text-gray-400" : ""}`}
               onClick={() => {
                 _setModel(m);
                 setDropDown(false);
@@ -124,11 +124,15 @@ export const ModelSelector = ({
             </li>
             ))}
             <li
-              className='px-4 py-0 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer text-gray-600 dark:text-gray-300 flex justify-center items-center'
+              className='px-4 py-0 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer text-gray-600 dark:text-gray-300 flex justify-center items-center rounded-b-lg'
               onClick={() => setAdvancedModels(!advancedModels)}
             >
               <span
-                className={'ml-2'}
+                className={`ml-2${
+                  advancedModels
+                    ? "text-gray-700 dark:text-gray-300"
+                    : "text-gray-500 dark:text-gray-500"
+                }`}
               >{advancedModels ? '▲' : '▼'}</span>
             </li>
         </ul>

--- a/src/components/ConfigMenu/ConfigMenu.tsx
+++ b/src/components/ConfigMenu/ConfigMenu.tsx
@@ -79,6 +79,16 @@ export const ModelSelector = ({
   _setModel: React.Dispatch<React.SetStateAction<ModelOptions>>;
 }) => {
   const [dropDown, setDropDown] = useState<boolean>(false);
+  const [advancedModels, setAdvancedModels] = useState<boolean>(false);
+
+  const filterModelOptions = () => {
+    if (advancedModels) {
+      return modelOptions;
+    } else {
+      return modelOptions.slice(0,modelOptions.indexOf('gpt-4-32k')+1);
+    }
+  };
+  const filteredModelOptions = filterModelOptions();
 
   return (
     <div className='mb-4'>
@@ -101,7 +111,7 @@ export const ModelSelector = ({
           className='text-sm text-gray-700 dark:text-gray-200 p-0 m-0'
           aria-labelledby='dropdownDefaultButton'
         >
-          {modelOptions.map((m) => (
+          {filteredModelOptions.map((m,i) => (
             <li
               className='px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer'
               onClick={() => {
@@ -112,7 +122,15 @@ export const ModelSelector = ({
             >
               {m}
             </li>
-          ))}
+            ))}
+            <li
+              className='px-4 py-0 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer text-gray-600 dark:text-gray-300 flex justify-center items-center'
+              onClick={() => setAdvancedModels(!advancedModels)}
+            >
+              <span
+                className={'ml-2'}
+              >{advancedModels ? '▲' : '▼'}</span>
+            </li>
         </ul>
       </div>
     </div>

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -22,9 +22,9 @@ export const modelOptions: ModelOptions[] = [
   'gpt-3.5-turbo-16k',
   'gpt-4',
   'gpt-4-32k',
-  // 'gpt-3.5-turbo-0301',
-  // 'gpt-4-0314',
-  // 'gpt-4-32k-0314',
+  'gpt-3.5-turbo-0301',
+  'gpt-4-0314',
+  'gpt-4-32k-0314',
 ];
 
 export const defaultModel = 'gpt-3.5-turbo';

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -49,10 +49,7 @@ export interface Folder {
   color?: string;
 }
 
-export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' ;
-// | 'gpt-3.5-turbo-0301';
-// | 'gpt-4-0314'
-// | 'gpt-4-32k-0314'
+export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo-0301'| 'gpt-4-0314' | 'gpt-4-32k-0314';
 
 export type TotalTokenUsed = {
   [model in ModelOptions]?: {


### PR DESCRIPTION
Added an expansion button to the model selector that exposes `gpt-3.5-turbo-0301, gpt-4-0314, gpt-4-32k-0314`. 
I also gave the hover highlight rounded corners, to match the selection box's corners.
| default | expanded |
|--------|--------|
| <img width="149" alt="image" src="https://github.com/ztjhz/BetterChatGPT/assets/79812460/2d6efc3e-d439-4798-84de-9142a0f3c6ee"> | <img width="172" alt="image" src="https://github.com/ztjhz/BetterChatGPT/assets/79812460/a95551a1-2977-4380-aabb-1619d6a03d31"> | 

I've been hearing anecdotally that `gpt-4-0314` performs better than `gpt-4-0613(current)`, so i think it's fair to add these for extra customization/evaluations. 

[They aren't being removed from the API until next year](https://openai.com/blog/function-calling-and-other-api-updates):
> July 20, 2023 update:
>We previously communicated to developers that gpt-3.5-turbo-0301, gpt-4-0314 and gpt-4-32k-0314 models were scheduled for sunset on Sept 13, 2023. After reviewing feedback from customers and our community, we are extending support for those models until at least June 13, 2024.