### PR TITLE
Reveal "default chat config" as menu item

### DIFF
--- a/src/components/ChatConfigMenu/ChatConfigMenu.tsx
+++ b/src/components/ChatConfigMenu/ChatConfigMenu.tsx
@@ -32,7 +32,7 @@ const ChatConfigMenu = () => {
   );
 };
 
-const ChatConfigPopup = ({
+export const ChatConfigPopup = ({
   setIsModalOpen,
 }: {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/components/Menu/MenuOptions/DefaultChatConfig.tsx
+++ b/src/components/Menu/MenuOptions/DefaultChatConfig.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ChatIcon from '@icon/ChatIcon';
+import { ChatConfigPopup } from '@components/ChatConfigMenu/ChatConfigMenu';
+
+const Config = () => {
+  const { t } = useTranslation('model');
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  return (
+    <>
+      <a
+        className='flex py-2 px-2 items-center gap-3 rounded-md hover:bg-gray-500/10 transition-colors duration-200 text-white cursor-pointer text-sm'
+        id='api-menu'
+        onClick={() => setIsModalOpen(true)}
+      >
+        <ChatIcon />
+        {t('defaultChatConfig')}
+      </a>
+      {isModalOpen && <ChatConfigPopup setIsModalOpen={setIsModalOpen} />}
+    </>
+  );
+};
+
+export default Config;

--- a/src/components/Menu/MenuOptions/MenuOptions.tsx
+++ b/src/components/Menu/MenuOptions/MenuOptions.tsx
@@ -5,6 +5,7 @@ import Api from './Api';
 import Me from './Me';
 import AboutMenu from '@components/AboutMenu';
 import ImportExportChat from '@components/ImportExportChat';
+import DefaultChatConfig from './DefaultChatConfig';
 import SettingsMenu from '@components/SettingsMenu';
 import CollapseOptions from './CollapseOptions';
 import GoogleSync from '@components/GoogleSync';
@@ -28,6 +29,7 @@ const MenuOptions = () => {
         <AboutMenu />
         <ImportExportChat />
         <Api />
+        <DefaultChatConfig />
         <SettingsMenu />
         <Me />
       </div>


### PR DESCRIPTION
I've been using this application exclusively for GPT-4. I didn't realize until diving into the app's source code that the default settings for the chat could be changed. As a result, I'd been manually switching from the default GPT-3.5 setting to GPT-4 all along, which I found bothersome.

The default settings of the chat are a very significant aspect for the user experience, so I would prefer them to be displayed in a more understandable position. Therefore, I have submitted this pull request.