### PR TITLE
fix: ignore comment events

### DIFF
--- a/src/api/helper.ts
+++ b/src/api/helper.ts
@@ -6,6 +6,7 @@ export const parseEventSource = (
   const result = data
     .split('\n\n')
     .filter(Boolean)
+    .filter((chunk) => chunk.startsWith(":")) // Ignore SSE comment event
     .map((chunk) => {
       const jsonString = chunk
         .split('\n')


### PR DESCRIPTION
Per SSE specs, we should ignore comment event or process it accordingly. This should bypass all comment: 

https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation