### PR TITLE
Fix max tokens and add model options

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -38,7 +38,7 @@ export const getChatCompletion = async (
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: undefined,
+      max_tokens: config.max_tokens,
     }),
   });
   if (!response.ok) throw new Error(await response.text());
@@ -83,7 +83,7 @@ export const getChatCompletionStream = async (
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: undefined,
+      max_tokens: config.max_tokens,
       stream: true,
     }),
   });

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -35,7 +35,7 @@ export const getChatCompletion = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount-1);
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -83,7 +83,7 @@ export const getChatCompletionStream = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount-1);
   
   const response = await fetch(endpoint, {
     method: 'POST',

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -35,7 +35,7 @@ export const getChatCompletion = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-3;
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-4;
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -83,7 +83,7 @@ export const getChatCompletionStream = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-3;
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-4;
   
   const response = await fetch(endpoint, {
     method: 'POST',

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -35,7 +35,7 @@ export const getChatCompletion = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-4;
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -83,7 +83,7 @@ export const getChatCompletionStream = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-4;
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
   
   const response = await fetch(endpoint, {
     method: 'POST',

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -35,7 +35,7 @@ export const getChatCompletion = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-1;
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-3;
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -83,7 +83,7 @@ export const getChatCompletionStream = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-1;
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-3;
   
   const response = await fetch(endpoint, {
     method: 'POST',

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,8 @@
 import { ShareGPTSubmitBodyInterface } from '@type/api';
 import { ConfigInterface, MessageInterface } from '@type/chat';
 import { isAzureEndpoint } from '@utils/api';
+import { modelMaxToken } from '@constants/chat';
+import countTokens from '@utils/messageUtils';
 
 export const getChatCompletion = async (
   endpoint: string,
@@ -32,13 +34,16 @@ export const getChatCompletion = async (
     }
   }
 
+  const tokenCount = countTokens(messages, config.model);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: config.max_tokens,
+      max_tokens: maxTokens,
     }),
   });
   if (!response.ok) throw new Error(await response.text());
@@ -77,13 +82,16 @@ export const getChatCompletionStream = async (
     }
   }
 
+  const tokenCount = countTokens(messages, config.model);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-1;
+  
   const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({
       messages,
       ...config,
-      max_tokens: config.max_tokens,
+      max_tokens: maxTokens,
       stream: true,
     }),
   });

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -35,7 +35,7 @@ export const getChatCompletion = async (
   }
 
   const tokenCount = countTokens(messages, config.model);
-  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount);
+  const maxTokens = Math.min(config.max_tokens, modelMaxToken[config.model] - tokenCount)-1;
 
   const response = await fetch(endpoint, {
     method: 'POST',

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -42,15 +42,10 @@ export const modelMaxToken = {
   'gpt-4-32k': 32768,
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
-  'openai/gpt-3.5-turbo':4096
 };
 
 export const modelCost = {
   'gpt-3.5-turbo': {
-    prompt: { price: 0.0015, unit: 1000 },
-    completion: { price: 0.002, unit: 1000 },
-  },
-  'openai/gpt-3.5-turbo': {
     prompt: { price: 0.0015, unit: 1000 },
     completion: { price: 0.002, unit: 1000 },
   },

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -22,9 +22,10 @@ export const modelOptions: ModelOptions[] = [
   'gpt-3.5-turbo-16k',
   'gpt-4',
   'gpt-4-32k',
-  // 'gpt-3.5-turbo-0301',
-  // 'gpt-4-0314',
-  // 'gpt-4-32k-0314',
+  'gpt-4-0314',
+  'gpt-4-32k-0314',
+  'gpt-3.5-turbo-0301',
+  'gpt-3.5-turbo-0613',
 ];
 
 export const defaultModel = 'gpt-3.5-turbo';
@@ -41,10 +42,15 @@ export const modelMaxToken = {
   'gpt-4-32k': 32768,
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
+  'openai/gpt-3.5-turbo':4096
 };
 
 export const modelCost = {
   'gpt-3.5-turbo': {
+    prompt: { price: 0.0015, unit: 1000 },
+    completion: { price: 0.002, unit: 1000 },
+  },
+  'openai/gpt-3.5-turbo': {
     prompt: { price: 0.0015, unit: 1000 },
     completion: { price: 0.002, unit: 1000 },
   },
@@ -100,7 +106,14 @@ export const _defaultChatConfig: ConfigInterface = {
   top_p: 1,
   frequency_penalty: 0,
 };
-
+export const _generateTitleConfig:ConfigInterface = {
+  model: defaultModel,
+  max_tokens: 200,//Only 6 words in title according to the prompt
+  temperature: 0,//for stable titles
+  presence_penalty: 0,
+  top_p: 1,
+  frequency_penalty: 0,
+};
 export const generateDefaultChat = (
   title?: string,
   folder?: string

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -49,10 +49,7 @@ export interface Folder {
   color?: string;
 }
 
-export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' ;
-// | 'gpt-3.5-turbo-0301';
-// | 'gpt-4-0314'
-// | 'gpt-4-32k-0314'
+export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo-0301'|'gpt-3.5-turbo-0613'| 'gpt-4-0314'| 'gpt-4-32k-0314'
 
 export type TotalTokenUsed = {
   [model in ModelOptions]?: {


### PR DESCRIPTION
1.max_tokens没有被正确传入，该版本传入了参数，使用了Math.min方法确保max_tokens始终合法
2.添加了一个额外的配置，专用于生成标题，设置了温度为0以得到稳定的标题
3.恢复了被注释掉的模型选项，因为不同模型的能力和速度的确有差异

你可以先在这里测试：https://redwinda.github.io/BetterChatGPT-origin/

English verion: 
1. The parameter max_tokens was not correctly passed, but in this version it has been passed and the Math.min method has been used to ensure that max_tokens is always valid.
2. An additional configuration has been added specifically for generating titles, with a temperature of 0 set to obtain stable titles.
3. The commented-out model options have been restored because there are indeed differences in the capabilities and speed of different models.

You can test it here first: https://redwinda.github.io/BetterChatGPT-origin/