### PR TITLE
Add support for Vision API

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,19 @@
 import { ShareGPTSubmitBodyInterface } from '@type/api';
-import { ConfigInterface, MessageInterface, ModelOptions } from '@type/chat';
+import { ConfigInterface, ImageContentInterface, MessageInterface, ModelOptions } from '@type/chat';
 import { isAzureEndpoint } from '@utils/api';
+
+
+// convert message blob urls to base64
+const blobToBase64 = async (blob: Blob) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = () => {
+      resolve(reader.result);
+    };
+    reader.readAsDataURL(blob);
+  });
+};
 
 export const getChatCompletion = async (
   endpoint: string,
@@ -41,11 +54,37 @@ export const getChatCompletion = async (
     }
   }
 
+  // do this for all the messages that have image content
+  const validMessages = await Promise.all(
+    messages.map(async (message) => {
+      return {
+        ...message,
+        content: message.content.map(async (content) => {
+          if ('image_url' in content) {
+            let imageContent = content as ImageContentInterface
+            if (imageContent.image_url.url.startsWith('blob:')) {
+              const blob = await fetch(imageContent.image_url.url).then((r) => r.blob());
+              let base64 = await blobToBase64(blob)
+              let url = `data:image/jpeg;base64,${base64}`
+              console.log(url)
+              return {
+                ...imageContent,
+                image_url: {
+                  url: url
+                }
+              }
+            }
+            return message.content;
+          }
+        })
+      }
+    }))
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({
-      messages,
+      validImages: validMessages,
       ...config,
       max_tokens: undefined,
     }),
@@ -94,13 +133,41 @@ export const getChatCompletionStream = async (
     }
   }
 
+  const validMessages = await Promise.all(
+    messages.map(async (message) => {
+      return {
+        ...message,
+        content: await Promise.all(message.content.map(async (content) => {
+          if ('image_url' in content) {
+            let imageContent = content as ImageContentInterface
+            if (imageContent.image_url.url.startsWith('blob:')) {
+              const blob = await fetch(imageContent.image_url.url).then((r) => r.blob());
+              let base64 = await blobToBase64(blob)
+              let url = base64
+              console.log(url)
+              return {
+                type: 'image_url',
+                image_url: {
+                  url: url
+                }
+              }
+            }
+            // if not a locally stored image (future we can allow for urls from internet)
+            return content;
+          }
+          // if text and not image_url
+          return content;
+        }))
+      }
+    }))
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({
-      messages,
+      messages: validMessages,
       ...config,
-      max_tokens: undefined,
+      max_tokens: config.max_tokens,
       stream: true,
     }),
   });
@@ -110,7 +177,7 @@ export const getChatCompletionStream = async (
     if (text.includes('model_not_found')) {
       throw new Error(
         text +
-          '\nMessage from Better ChatGPT:\nPlease ensure that you have access to the GPT-4 API!'
+        '\nMessage from Better ChatGPT:\nPlease ensure that you have access to the GPT-4 API!'
       );
     } else {
       throw new Error(

--- a/src/components/Chat/ChatContent/ChatContent.tsx
+++ b/src/components/Chat/ChatContent/ChatContent.tsx
@@ -12,6 +12,7 @@ import useSubmit from '@hooks/useSubmit';
 import DownloadChat from './DownloadChat';
 import CloneChat from './CloneChat';
 import ShareGPT from '@components/ShareGPT';
+import { ImageContentInterface, TextContentInterface } from '@type/chat';
 
 const ChatContent = () => {
   const inputRole = useStore((state) => state.inputRole);
@@ -68,7 +69,8 @@ const ChatContent = () => {
                 <React.Fragment key={index}>
                   <Message
                     role={message.role}
-                    content={message.content}
+                    text={(message.content[0] as TextContentInterface).text}
+                    image_urls={message.content[1] ? (message.content.slice(1) as ImageContentInterface[]).map((imageContent) => imageContent.image_url.url) : []}
                     messageIndex={index}
                   />
                   {!generating && advancedMode && <NewMessageButton messageIndex={index} />}
@@ -79,7 +81,8 @@ const ChatContent = () => {
 
           <Message
             role={inputRole}
-            content=''
+            text=''
+            image_urls={[]}
             messageIndex={stickyIndex}
             sticky
           />

--- a/src/components/Chat/ChatContent/ChatContent.tsx
+++ b/src/components/Chat/ChatContent/ChatContent.tsx
@@ -69,8 +69,7 @@ const ChatContent = () => {
                 <React.Fragment key={index}>
                   <Message
                     role={message.role}
-                    text={(message.content[0] as TextContentInterface).text}
-                    image_urls={message.content[1] ? (message.content.slice(1) as ImageContentInterface[]).map((imageContent) => imageContent.image_url.url) : []}
+                    content={message.content}
                     messageIndex={index}
                   />
                   {!generating && advancedMode && <NewMessageButton messageIndex={index} />}
@@ -81,8 +80,10 @@ const ChatContent = () => {
 
           <Message
             role={inputRole}
-            text=''
-            image_urls={[]}
+            // For now we always initizlize a new message with an empty text content.
+            // It is possible to send a message to the API without a TextContentInterface, 
+            // but the UI would need to be modified to allow the user to control the order of text and image content
+            content={[{type: 'text', text: ''} as TextContentInterface]}
             messageIndex={stickyIndex}
             sticky
           />

--- a/src/components/Chat/ChatContent/Message/CommandPrompt/CommandPrompt.tsx
+++ b/src/components/Chat/ChatContent/Message/CommandPrompt/CommandPrompt.tsx
@@ -6,11 +6,12 @@ import { matchSorter } from 'match-sorter';
 import { Prompt } from '@type/prompt';
 
 import useHideOnOutsideClick from '@hooks/useHideOnOutsideClick';
+import { ContentInterface } from '@type/chat';
 
 const CommandPrompt = ({
   _setContent,
 }: {
-  _setContent: React.Dispatch<React.SetStateAction<string>>;
+  _setContent: React.Dispatch<React.SetStateAction<ContentInterface[]>>;
 }) => {
   const { t } = useTranslation();
   const prompts = useStore((state) => state.prompts);
@@ -69,7 +70,7 @@ const CommandPrompt = ({
             <li
               className='px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer text-start w-full'
               onClick={() => {
-                _setContent((prev) => prev + cp.prompt);
+                _setContent((prev) => [{type: 'text', text: prev + cp.prompt}, ...prev.slice(1)]);
                 setDropDown(false);
               }}
               key={cp.id}

--- a/src/components/Chat/ChatContent/Message/Message.tsx
+++ b/src/components/Chat/ChatContent/Message/Message.tsx
@@ -17,12 +17,14 @@ const backgroundStyle = ['dark:bg-gray-800', 'bg-gray-50 dark:bg-gray-650'];
 const Message = React.memo(
   ({
     role,
-    content,
+    text,
+    image_urls,
     messageIndex,
     sticky = false,
   }: {
     role: Role;
-    content: string;
+    text: string;
+    image_urls: string[];
     messageIndex: number;
     sticky?: boolean;
   }) => {
@@ -52,7 +54,8 @@ const Message = React.memo(
               />}
             <MessageContent
               role={role}
-              content={content}
+              text={text}
+              image_urls={image_urls}
               messageIndex={messageIndex}
               sticky={sticky}
             />

--- a/src/components/Chat/ChatContent/Message/Message.tsx
+++ b/src/components/Chat/ChatContent/Message/Message.tsx
@@ -4,7 +4,7 @@ import useStore from '@store/store';
 import Avatar from './Avatar';
 import MessageContent from './MessageContent';
 
-import { Role } from '@type/chat';
+import { ContentInterface, Role } from '@type/chat';
 import RoleSelector from './RoleSelector';
 
 // const backgroundStyle: { [role in Role]: string } = {
@@ -17,14 +17,12 @@ const backgroundStyle = ['dark:bg-gray-800', 'bg-gray-50 dark:bg-gray-650'];
 const Message = React.memo(
   ({
     role,
-    text,
-    image_urls,
+    content,
     messageIndex,
     sticky = false,
   }: {
     role: Role;
-    text: string;
-    image_urls: string[];
+    content: ContentInterface[],
     messageIndex: number;
     sticky?: boolean;
   }) => {
@@ -54,8 +52,7 @@ const Message = React.memo(
               />}
             <MessageContent
               role={role}
-              text={text}
-              image_urls={image_urls}
+              content={content}
               messageIndex={messageIndex}
               sticky={sticky}
             />

--- a/src/components/Chat/ChatContent/Message/MessageContent.tsx
+++ b/src/components/Chat/ChatContent/Message/MessageContent.tsx
@@ -6,12 +6,14 @@ import EditView from './View/EditView';
 
 const MessageContent = ({
   role,
-  content,
+  text,
+  image_urls,
   messageIndex,
   sticky = false,
 }: {
   role: string;
-  content: string;
+  text: string;
+  image_urls: string[];
   messageIndex: number;
   sticky?: boolean;
 }) => {
@@ -23,7 +25,8 @@ const MessageContent = ({
       {advancedMode && <div className='flex flex-grow flex-col gap-3'></div>}
       {isEdit ? (
         <EditView
-          content={content}
+          text={text}
+          image_urls={image_urls}
           setIsEdit={setIsEdit}
           messageIndex={messageIndex}
           sticky={sticky}
@@ -31,7 +34,8 @@ const MessageContent = ({
       ) : (
         <ContentView
           role={role}
-          content={content}
+          text={text}
+          image_urls={image_urls}
           setIsEdit={setIsEdit}
           messageIndex={messageIndex}
         />

--- a/src/components/Chat/ChatContent/Message/MessageContent.tsx
+++ b/src/components/Chat/ChatContent/Message/MessageContent.tsx
@@ -3,17 +3,16 @@ import useStore from '@store/store';
 
 import ContentView from './View/ContentView';
 import EditView from './View/EditView';
+import { ContentInterface } from '@type/chat';
 
 const MessageContent = ({
   role,
-  text,
-  image_urls,
+  content,
   messageIndex,
   sticky = false,
 }: {
   role: string;
-  text: string;
-  image_urls: string[];
+  content: ContentInterface[];
   messageIndex: number;
   sticky?: boolean;
 }) => {
@@ -25,8 +24,7 @@ const MessageContent = ({
       {advancedMode && <div className='flex flex-grow flex-col gap-3'></div>}
       {isEdit ? (
         <EditView
-          text={text}
-          image_urls={image_urls}
+          content={content}
           setIsEdit={setIsEdit}
           messageIndex={messageIndex}
           sticky={sticky}
@@ -34,8 +32,7 @@ const MessageContent = ({
       ) : (
         <ContentView
           role={role}
-          text={text}
-          image_urls={image_urls}
+          content={content}
           setIsEdit={setIsEdit}
           messageIndex={messageIndex}
         />

--- a/src/components/Chat/ChatContent/Message/View/ContentView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/ContentView.tsx
@@ -36,12 +36,14 @@ import CodeBlock from '../CodeBlock';
 const ContentView = memo(
   ({
     role,
-    content,
+    text,
+    image_urls,
     setIsEdit,
     messageIndex,
   }: {
     role: string;
-    content: string;
+    text: string;
+    image_urls: string[];
     setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
     messageIndex: number;
   }) => {
@@ -100,7 +102,7 @@ const ContentView = memo(
     };
 
     const handleCopy = () => {
-      navigator.clipboard.writeText(content);
+      navigator.clipboard.writeText(text);
     };
 
     return (
@@ -129,11 +131,18 @@ const ContentView = memo(
                 p,
               }}
             >
-              {content}
+              {text}
             </ReactMarkdown>
           ) : (
-            <span className='whitespace-pre-wrap'>{content}</span>
+            <span className='whitespace-pre-wrap'>{text}</span>
           )}
+        </div>
+        <div className="flex">
+          {image_urls.map((image, index) => (
+            <div key={index} className="image-container">
+              <img src={image} alt={`uploaded-${index}`} className="mr-2 h-20" />
+            </div>
+          ))}
         </div>
         <div className='flex justify-end gap-2 w-full mt-2'>
           {isDelete || (

--- a/src/components/Chat/ChatContent/Message/View/ContentView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/ContentView.tsx
@@ -19,7 +19,7 @@ import CrossIcon from '@icon/CrossIcon';
 
 import useSubmit from '@hooks/useSubmit';
 
-import { ChatInterface } from '@type/chat';
+import { ChatInterface, ContentInterface, ImageContentInterface, TextContentInterface } from '@type/chat';
 
 import { codeLanguageSubset } from '@constants/chat';
 
@@ -36,14 +36,12 @@ import CodeBlock from '../CodeBlock';
 const ContentView = memo(
   ({
     role,
-    text,
-    image_urls,
+    content,
     setIsEdit,
     messageIndex,
   }: {
     role: string;
-    text: string;
-    image_urls: string[];
+    content: ContentInterface[],
     setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
     messageIndex: number;
   }) => {
@@ -102,7 +100,7 @@ const ContentView = memo(
     };
 
     const handleCopy = () => {
-      navigator.clipboard.writeText(text);
+      navigator.clipboard.writeText((content[0] as TextContentInterface).text);
     };
 
     return (
@@ -131,16 +129,16 @@ const ContentView = memo(
                 p,
               }}
             >
-              {text}
+              {(content[0] as TextContentInterface).text}
             </ReactMarkdown>
           ) : (
-            <span className='whitespace-pre-wrap'>{text}</span>
+            <span className='whitespace-pre-wrap'>{(content[0] as TextContentInterface).text}</span>
           )}
         </div>
-        <div className="flex">
-          {image_urls.map((image, index) => (
+        <div className="flex gap-4">
+          {(content.slice(1) as ImageContentInterface[]).map((image, index) => (
             <div key={index} className="image-container">
-              <img src={image} alt={`uploaded-${index}`} className="mr-2 h-20" />
+              <img src={image.image_url.url} alt={`uploaded-${index}`} className="h-20" />
             </div>
           ))}
         </div>

--- a/src/components/Chat/ChatContent/Message/View/EditView.tsx
+++ b/src/components/Chat/ChatContent/Message/View/EditView.tsx
@@ -10,6 +10,7 @@ import PopupModal from '@components/PopupModal';
 import TokenCount from '@components/TokenCount';
 import CommandPrompt from '../CommandPrompt';
 import FolderIcon from '@icon/FolderIcon';
+import { modelTypes } from '@constants/chat';
 
 const EditView = ({
   content: content,
@@ -252,7 +253,7 @@ const EditViewButtons = memo(
 
     return (
       <div>
-        {model == 'gpt-4-vision-preview' && (
+        {modelTypes[model] == 'image' && (
           <div className='flex justify-center'>
             <div className="flex gap-5">
               {_content.slice(1).map((image, index) => (

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -123,6 +123,7 @@ type ModelTypes = {
   [x in ModelOptions]: ModelType;
 };
 
+// Types of input the model can support. If image, show an image upload button
 export const modelTypes: ModelTypes = {
   'gpt-3.5-turbo': 'text',
   'gpt-3.5-turbo-16k': 'text',

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { ChatInterface, ConfigInterface, ModelOptions } from '@type/chat';
+import { ChatInterface, ConfigInterface, ModelOptions, TextContentInterface } from '@type/chat';
 import useStore from '@store/store';
 
 const date = new Date();
@@ -23,7 +23,8 @@ export const modelOptions: ModelOptions[] = [
   'gpt-3.5-turbo-1106',
   'gpt-4',
   'gpt-4-32k',
-  'gpt-4-1106-preview'
+  'gpt-4-1106-preview',
+  'gpt-4-vision-preview'
   // 'gpt-3.5-turbo-0301',
   // 'gpt-4-0314',
   // 'gpt-4-32k-0314',
@@ -45,6 +46,7 @@ export const modelMaxToken = {
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
   'gpt-4-1106-preview': 128000,
+  'gpt-4-vision-preview': 128000
 };
 
 export const modelCost = {
@@ -100,6 +102,10 @@ export const modelCost = {
     prompt: { price: 0.01, unit: 1000 },
     completion: { price: 0.03, unit: 1000 },
   },
+  'gpt-4-vision-preview': {
+    prompt: { price: 0.01, unit: 1000 },
+    completion: { price: 0.03, unit: 1000 },
+  }
 };
 
 export const defaultUserMaxToken = 4000;
@@ -121,7 +127,7 @@ export const generateDefaultChat = (
   title: title ? title : 'New Chat',
   messages:
     useStore.getState().defaultSystemMessage.length > 0
-      ? [{ role: 'system', content: useStore.getState().defaultSystemMessage }]
+      ? [{ role: 'system', content: [{type: 'text', text: useStore.getState().defaultSystemMessage} as TextContentInterface] }]
       : [],
   config: { ...useStore.getState().defaultChatConfig },
   titleSet: false,

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { ChatInterface, ConfigInterface, ModelOptions, TextContentInterface } from '@type/chat';
+import { ChatInterface, ConfigInterface, ModelOptions, ModelType, TextContentInterface } from '@type/chat';
 import useStore from '@store/store';
 
 const date = new Date();
@@ -117,6 +117,22 @@ export const modelCost = {
     prompt: { price: 0.01, unit: 1000 },
     completion: { price: 0.03, unit: 1000 },
   }
+};
+
+type ModelTypes = {
+  [x in ModelOptions]: ModelType;
+};
+
+export const modelTypes: ModelTypes = {
+  'gpt-3.5-turbo': 'text',
+  'gpt-3.5-turbo-16k': 'text',
+  'gpt-3.5-turbo-1106': 'text',
+  'gpt-3.5-turbo-0125': 'text',
+  'gpt-4': 'text',
+  'gpt-4-32k': 'text',
+  'gpt-4-1106-preview': 'text',
+  'gpt-4-0125-preview': 'text',
+  'gpt-4-vision-preview': 'image'
 };
 
 export const defaultUserMaxToken = 4000;

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import useStore from '@store/store';
 import { useTranslation } from 'react-i18next';
-import { ChatInterface, MessageInterface } from '@type/chat';
+import { ChatInterface, MessageInterface, TextContentInterface } from '@type/chat';
 import { getChatCompletion, getChatCompletionStream } from '@api/api';
 import { parseEventSource } from '@api/helper';
 import { limitMessageTokens, updateTotalTokenUsed } from '@utils/messageUtils';
@@ -59,7 +59,10 @@ const useSubmit = () => {
 
     updatedChats[currentChatIndex].messages.push({
       role: 'assistant',
-      content: '',
+      content: [{
+        type: 'text',
+        text: ''
+      } as TextContentInterface],
     });
 
     setChats(updatedChats);
@@ -132,7 +135,7 @@ const useSubmit = () => {
               JSON.stringify(useStore.getState().chats)
             );
             const updatedMessages = updatedChats[currentChatIndex].messages;
-            updatedMessages[updatedMessages.length - 1].content += resultString;
+            (updatedMessages[updatedMessages.length - 1].content[0] as TextContentInterface).text += resultString;
             setChats(updatedChats);
           }
         }
@@ -173,7 +176,10 @@ const useSubmit = () => {
 
         const message: MessageInterface = {
           role: 'user',
-          content: `Generate a title in less than 6 words for the following message (language: ${i18n.language}):\n"""\nUser: ${user_message}\nAssistant: ${assistant_message}\n"""`,
+          content: [{
+            type: 'text',
+            text: `Generate a title in less than 6 words for the following message (language: ${i18n.language}):\n"""\nUser: ${user_message}\nAssistant: ${assistant_message}\n"""`,
+          } as TextContentInterface]
         };
 
         let title = (await generateTitle([message])).trim();
@@ -192,7 +198,7 @@ const useSubmit = () => {
           const model = _defaultChatConfig.model;
           updateTotalTokenUsed(model, [message], {
             role: 'assistant',
-            content: title,
+            content: [{type: 'text', text: title} as TextContentInterface],
           });
         }
       }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -86,6 +86,8 @@ export type ModelOptions =
 // | 'gpt-4-0314'
 // | 'gpt-4-32k-0314'
 
+export type ModelType = 'text' | 'image';
+
 export type TotalTokenUsed = {
   [model in ModelOptions]?: {
     promptTokens: number;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,12 +1,31 @@
 import { Prompt } from './prompt';
 import { Theme } from './theme';
 
+// The types in this file must mimick the structure of the the API request
+
+export type Content = 'text' | 'image_url';
 export type Role = 'user' | 'assistant' | 'system';
 export const roles: Role[] = ['user', 'assistant', 'system'];
 
+export interface ImageContentInterface extends ContentInterface {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  }
+}
+
+export interface TextContentInterface extends ContentInterface {
+  type: 'text';
+  text: string;
+}
+
+export interface ContentInterface {
+  type: Content;
+}
+
 export interface MessageInterface {
   role: Role;
-  content: string;
+  content: ContentInterface[];
 }
 
 export interface ChatInterface {
@@ -49,7 +68,7 @@ export interface Folder {
   color?: string;
 }
 
-export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-4-1106-preview' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo-1106' ;
+export type ModelOptions = 'gpt-4' | 'gpt-4-32k' | 'gpt-4-1106-preview' | 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo-1106' | 'gpt-4-vision-preview' ;
 // | 'gpt-3.5-turbo-0301';
 // | 'gpt-4-0314'
 // | 'gpt-4-32k-0314'

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -4,13 +4,16 @@ import { Theme } from './theme';
 // The types in this file must mimick the structure of the the API request
 
 export type Content = 'text' | 'image_url';
+export type ImageDetail = 'low' | 'high' | 'auto';
+export const imageDetails: ImageDetail[] = ['low', 'high', 'auto'];
 export type Role = 'user' | 'assistant' | 'system';
 export const roles: Role[] = ['user', 'assistant', 'system'];
 
 export interface ImageContentInterface extends ContentInterface {
   type: 'image_url';
   image_url: {
-    url: string;
+    url: string; // base64 or image URL
+    detail: ImageDetail;
   }
 }
 
@@ -20,6 +23,7 @@ export interface TextContentInterface extends ContentInterface {
 }
 
 export interface ContentInterface {
+  [x: string]: any;
   type: Content;
 }
 
@@ -166,3 +170,7 @@ export interface LocalStorageInterfaceV7oV8
   foldersExpanded: boolean[];
   folders: FolderCollection;
 }
+
+// export interface LocalStorageInterfaceV8ToV9
+//   extends LocalStorageInterfaceV7oV8 {
+    

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -1,4 +1,4 @@
-import { MessageInterface, ModelOptions, TotalTokenUsed } from '@type/chat';
+import { MessageInterface, ModelOptions, TextContentInterface, TotalTokenUsed } from '@type/chat';
 
 import useStore from '@store/store';
 
@@ -29,7 +29,7 @@ export const getChatGPTEncoding = (
   const serialized = [
     messages
       .map(({ role, content }) => {
-        return `<|im_start|>${role}${roleSep}${content}<|im_end|>`;
+        return `<|im_start|>${role}${roleSep}${(content[0] as TextContentInterface).text}<|im_end|>`;
       })
       .join(msgSep),
     `<|im_start|>assistant${roleSep}`,


### PR DESCRIPTION
Adds the ability to use the vision API in the client. Resolves #488 and #473 

Message interface:
![image](https://github.com/ztjhz/BetterChatGPT/assets/22477298/1036412d-ca5b-41d8-8994-7fa7dbd4d8bf)

Editing interface:
![image](https://github.com/ztjhz/BetterChatGPT/assets/22477298/30bd916c-d6c4-499e-9d37-c9764ca466b1)


- [X] Add image to blob (base64) conversion when a file is uploaded, and store that base64 in the browser (localstorage). Not perfect and localstorage might run out of space but I don't have any other better solutions to keep the images you store from previous chats and IndexedDB looks too hard to implement.
- [X] Add image detail selection for users to select which detail their image should be processed at. see: https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding
- [X]  Add a new data structure to differentiate models based on the types of inputs they can take and update editor to check if model supports images or not. I added a const `modelTypes` and check for it in `EditView.tsx`
- [X] Clean up the image upload UI (it's not perfect, but works)
- [ ] Need to make some data structure version migration function so that clients with old data structures will get theirs updated (I need help with this)

### Notable changes
This PR changes the the data structures of `ChatInterface`, `MessageInterface`, and creates `ContentInterface`, `TextContentInterface` and `ImageContentInterface` so that it follows the updated API JSON structure for prompts that contain images.

Before:
```ts
export interface MessageInterface {
  role: Role;
  content: string;
}
```

After:
```ts
export type Content = 'text' | 'image_url';

export interface ImageContentInterface extends ContentInterface {
  type: 'image_url';
  image_url: {
    url: string;
  }
}

export interface TextContentInterface extends ContentInterface {
  type: 'text';
  text: string;
}

export interface ContentInterface {
  type: Content;
}

export interface MessageInterface {
  role: Role;
  content: ContentInterface[];
}
```

The `url` parameter stores the URL of the image locally (the `blob:` URL) and at generation-time the client converts all the blob URLs into base64 for the [API to take in](https://platform.openai.com/docs/guides/vision/uploading-base-64-encoded-images). 