### PR TITLE
Server-Sent-Events compliance: Allow space in front of value

### DIFF
--- a/src/api/helper.ts
+++ b/src/api/helper.ts
@@ -9,7 +9,7 @@ export const parseEventSource = (
     .map((chunk) => {
       const jsonString = chunk
         .split('\n')
-        .map((line) => line.replace(/^data: /, ''))
+        .map((line) => line.replace(/^data: ?/, ''))
         .join('');
       if (jsonString === '[DONE]') return jsonString;
       try {


### PR DESCRIPTION
According to the [Spec for SSE](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), when a line contains a colon character, the first colon separates `field` and `value`.

A space in front of the `value` field is allowed, but not required.
>[..] If value starts with a U+0020 SPACE character, remove it from value.

This Patch makes the regex-space optional to archive that.

If interested: I found this issue when i implemented the API and wanted to use it, but the web-library gin sends Server-Sent-Events without the space, thus not working at all.