### PR TITLE
Adding Node/NPM version info to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ One click deploy with Vercel
 
 1. Ensure that you have the following installed:
 
-   - [node.js](https://nodejs.org/en/)
-   - [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/)
+   - [node.js](https://nodejs.org/en/) (v14.18.0 or Above)
+   - [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) (6.14.15 or above)
 
 2. Clone this [repository](https://github.com/ztjhz/BetterChatGPT) by running `git clone https://github.com/ztjhz/BetterChatGPT.git`
 3. Navigate into the directory by running `cd BetterChatGPT`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ One click deploy with Vercel
 
 1. Ensure that you have the following installed:
 
-   - [node.js](https://nodejs.org/en/) (v14.18.0 or Above)
+   - [node.js](https://nodejs.org/en/) (v14.18.0 or above)
    - [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) (6.14.15 or above)
 
 2. Clone this [repository](https://github.com/ztjhz/BetterChatGPT) by running `git clone https://github.com/ztjhz/BetterChatGPT.git`


### PR DESCRIPTION
Updating the readme to show the minimum version of node and npm required to run BetterGPT Locally.
![image](https://github.com/ztjhz/BetterChatGPT/assets/51441497/5677d05e-f51f-4dcf-8134-65b55462360b)

