### PR TITLE
fix a typo in gpt-4-0125 context length

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -48,7 +48,7 @@ export const modelMaxToken = {
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
   'gpt-4-1106-preview': 128000,
-  'gpt-4-0125-preview': 4096,
+  'gpt-4-0125-preview': 128000,
 };
 
 export const modelCost = {


### PR DESCRIPTION
There is an important typo in the latest `gpt-4-0125-preview` context length. 
It should be 128k instead of 4k as in `gpt-4-1106-preview`.
https://github.com/ztjhz/BetterChatGPT/blob/ecad41fd729cb36968aa4866391692d02a51af89/src/constants/chat.ts#L50-L51

source: https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo

closes https://github.com/ztjhz/BetterChatGPT/issues/533

cc: @ztjhz 