### PR TITLE
Added GPT-4 Turbo and GPT-4 Turbo Preview to chat models, tokens, and cost

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -24,6 +24,8 @@ export const modelOptions: ModelOptions[] = [
   'gpt-3.5-turbo-0125',
   'gpt-4',
   'gpt-4-32k',
+  'gpt-4-turbo',
+  'gpt-4-turbo-preview',
   'gpt-4-1106-preview',
   'gpt-4-0125-preview'
   // 'gpt-3.5-turbo-0301',
@@ -47,6 +49,8 @@ export const modelMaxToken = {
   'gpt-4-32k': 32768,
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
+  'gpt-4-turbo': 128000,
+  'gpt-4-turbo-preview': 128000,
   'gpt-4-1106-preview': 128000,
   'gpt-4-0125-preview': 128000,
 };
@@ -83,6 +87,14 @@ export const modelCost = {
   'gpt-4': {
     prompt: { price: 0.03, unit: 1000 },
     completion: { price: 0.06, unit: 1000 },
+  },
+  'gpt-4-turbo': {
+    prompt: { price: 10.00, unit: 1000000 },
+    completion: { price: 30.00, unit: 1000000 },
+  },
+  'gpt-4-turbo-preview': {
+    prompt: { price: 10.00, unit: 1000000 },
+    completion: { price: 30.00, unit: 1000000 },
   },
   'gpt-4-0314': {
     prompt: { price: 0.03, unit: 1000 },

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -54,6 +54,8 @@ export type ModelOptions =
   | 'gpt-4-32k'
   | 'gpt-4-1106-preview'
   | 'gpt-4-0125-preview'
+  | 'gpt-4-turbo'
+  | 'gpt-4-turbo-preview'
   | 'gpt-3.5-turbo'
   | 'gpt-3.5-turbo-16k'
   | 'gpt-3.5-turbo-1106'


### PR DESCRIPTION
For both 'gpt-4-turbo' and 'gpt-4-turbo-preview', they each have been assigned a max token value of 128000, a prompt price of 10.00 per 1,000,000 units, and a completion price of 30.00 per 1,000,000 units.