### PR TITLE
Added support for "gpt-4o-2024-08-06" model

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -30,6 +30,7 @@ export const modelOptions: ModelOptions[] = [
   'gpt-4-turbo-2024-04-09',
   'gpt-4o',
   'gpt-4o-2024-05-13',
+  'gpt-4o-2024-08-06',
   // 'gpt-3.5-turbo-0301',
   // 'gpt-4-0314',
   // 'gpt-4-32k-0314',
@@ -57,6 +58,7 @@ export const modelMaxToken = {
   'gpt-4-turbo-2024-04-09': 128000,
   'gpt-4o': 128000,
   'gpt-4o-2024-05-13': 128000,
+  'gpt-4o-2024-08-06': 128000,
 };
 
 export const modelCost = {
@@ -135,6 +137,10 @@ export const modelCost = {
   'gpt-4o-2024-05-13': {
     prompt: { price: 0.005, unit: 1000 },
     completion: { price: 0.015, unit: 1000 },
+  },
+  'gpt-4o-2024-08-06': {
+    prompt: { price: 0.0025, unit: 1000 },
+    completion: { price: 0.01, unit: 1000 },
   },
 };
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -61,7 +61,8 @@ export type ModelOptions =
   | 'gpt-3.5-turbo'
   | 'gpt-3.5-turbo-16k'
   | 'gpt-3.5-turbo-1106'
-  | 'gpt-3.5-turbo-0125';
+  | 'gpt-3.5-turbo-0125'
+  | 'gpt-4o-2024-08-06';
 // | 'gpt-3.5-turbo-0301';
 // | 'gpt-4-0314'
 // | 'gpt-4-32k-0314'


### PR DESCRIPTION
I have already set up model costs and maximum tokens accordingly.

Information:
https://platform.openai.com/docs/models/continuous-model-upgrades

Pricing:
https://openai.com/pricing#language-models