### PR TITLE
Add gpt-4o-mini and update default model

### DIFF
--- a/src/components/TokenCount/TokenCount.tsx
+++ b/src/components/TokenCount/TokenCount.tsx
@@ -3,7 +3,7 @@ import useStore from '@store/store';
 import { shallow } from 'zustand/shallow';
 
 import countTokens from '@utils/messageUtils';
-import { modelCost } from '@constants/chat';
+import { modelCost, defaultModel } from '@constants/chat';
 
 const TokenCount = React.memo(() => {
   const [tokenCount, setTokenCount] = useState<number>(0);
@@ -17,7 +17,7 @@ const TokenCount = React.memo(() => {
   const model = useStore((state) =>
     state.chats
       ? state.chats[state.currentChatIndex].config.model
-      : 'gpt-3.5-turbo'
+      : defaultModel
   );
 
   const cost = useMemo(() => {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -30,9 +30,8 @@ export const modelOptions: ModelOptions[] = [
   'gpt-4-turbo-2024-04-09',
   'gpt-4o',
   'gpt-4o-2024-05-13',
-  // 'gpt-3.5-turbo-0301',
-  // 'gpt-4-0314',
-  // 'gpt-4-32k-0314',
+  'gpt-4o-mini',
+  'gpt-4o-mini-2024-07-18',
 ];
 
 export const defaultModel = 'gpt-3.5-turbo';
@@ -57,6 +56,8 @@ export const modelMaxToken = {
   'gpt-4-turbo-2024-04-09': 128000,
   'gpt-4o': 128000,
   'gpt-4o-2024-05-13': 128000,
+  'gpt-4o-mini': 128000,
+  'gpt-4o-mini-2024-07-18': 128000,
 };
 
 export const modelCost = {
@@ -135,6 +136,14 @@ export const modelCost = {
   'gpt-4o-2024-05-13': {
     prompt: { price: 0.005, unit: 1000 },
     completion: { price: 0.015, unit: 1000 },
+  },
+  'gpt-4o-mini': {
+    prompt: { price: 0.00015, unit: 1000 },
+    completion: { price: 0.0006, unit: 1000 },
+  },
+  'gpt-4o-mini-2024-07-18': {
+    prompt: { price: 0.00015, unit: 1000 },
+    completion: { price: 0.0006, unit: 1000 },
   },
 };
 

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -34,7 +34,7 @@ export const modelOptions: ModelOptions[] = [
   'gpt-4o-mini-2024-07-18',
 ];
 
-export const defaultModel = 'gpt-3.5-turbo';
+export const defaultModel = 'gpt-4o-mini';
 
 export const modelMaxToken = {
   'gpt-3.5-turbo': 4096,

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -50,6 +50,8 @@ export interface Folder {
 }
 
 export type ModelOptions =
+  | 'gpt-4o-mini'
+  | 'gpt-4o-mini-2024-07-18'
   | 'gpt-4o'
   | 'gpt-4o-2024-05-13'
   | 'gpt-4'
@@ -62,9 +64,6 @@ export type ModelOptions =
   | 'gpt-3.5-turbo-16k'
   | 'gpt-3.5-turbo-1106'
   | 'gpt-3.5-turbo-0125';
-// | 'gpt-3.5-turbo-0301';
-// | 'gpt-4-0314'
-// | 'gpt-4-32k-0314'
 
 export type TotalTokenUsed = {
   [model in ModelOptions]?: {


### PR DESCRIPTION
`gpt-4o-mini` is more capable and cheaper than `gpt-3.5-turbo`.

Information:
https://platform.openai.com/docs/models/gpt-4o-mini

Pricing:
https://openai.com/api/pricing/