### PR TITLE
docs: add aliyun computenest deploy to README.md & README-zh_CN.md

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -102,6 +102,12 @@ Better ChatGPT 已经包含了大量的功能。您可以使用以下功能：
 
 [![Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fztjhz%2FBetterChatGPT)
 
+## Aliyun ComputeNest
+
+使用 Aliyun ComputeNest 一键部署
+
+[![Deploy on Aliyun ComputeNest](https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest.svg)](https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=BetterChatGPT%E7%A4%BE%E5%8C%BA%E7%89%88)
+
 ## GitHub 页面
 
 ### 步骤

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ One click deploy with Vercel
 
 [![Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fztjhz%2FBetterChatGPT)
 
+## AlibabaCloud ComputeNest
+
+One click deploy with AlibabaCloud ComputeNest
+
+[![Deploy on AlibabaCloud ComputeNest](https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest-en.svg)](https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=BetterChatGPT%E7%A4%BE%E5%8C%BA%E7%89%88)
+
+
 ## GitHub Pages
 
 ### Steps


### PR DESCRIPTION
Hi team,

I have added a new deployment method using Alibaba Compute Nest that supports one-click deployment. Below are the deployment documents:

English: [Deploy Documentation](https://github.com/aliyun-computenest/quickstart-BetterChatGPT/blob/main/.computenest/docs/index-en.md)
Chinese (Simplified): [部署文档](https://github.com/aliyun-computenest/quickstart-BetterChatGPT/blob/main/.computenest/docs/index.md)
Please let me know if you have any questions or need further information.